### PR TITLE
Using expires_at instead of expires_in for ArtemisApi::Client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     hashdiff (0.4.0)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     jwt (2.2.1)
     minitest (5.11.3)
     multi_json (1.13.1)
@@ -28,6 +36,9 @@ GEM
     rack (2.0.7)
     rake (10.5.0)
     safe_yaml (1.0.5)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -37,6 +48,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   artemis_api!
   bundler (~> 1.16)
   minitest (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to use this gem, you will need to be set up as a developer in the Artem
 
 Once you have developer access, go to Settings and choose "OAuth 2.0 Applications" at the bottom of the sidebar to set up an application by entering the name and redirect URI you wish to use. You will then be provided with an application ID and a secret ID, which you will need in order to authenticate with Artemis.
 
-(Please note that this gem doesn't currently handle OAuth. You will need to do that on your own in order to generate your access token and refresh token. We recommend using the [OAuth2 gem](https://github.com/oauth-xx/oauth2))
+(Please note that this gem doesn't currently handle OAuth. You will need to do that on your own in order to generate your access token and refresh token. We recommend using the [OAuth2 gem](https://github.com/oauth-xx/oauth2). You'll also need to pass in the `expires_at` for when your token will exipire.)
 
 Once you have all this info, the first step to actually using this gem is to instantiate an instance of `ArtemisApi::Client` - which can be done one of two ways.
 
@@ -32,14 +32,14 @@ Once you have all this info, the first step to actually using this gem is to ins
 options = {app_id: 'your_artemis_application_id',
            app_secret: 'your_artemis_secret_id',
            base_uri: 'https://portal.artemisag.com'}
-client = ArtemisApi::Client.new('your_access_token', 'your_refresh_token', options)
+client = ArtemisApi::Client.new('your_access_token', 'your_refresh_token', token_expires_at, options)
 ```
 
 Alternatively, instead of passing in options, you can set those values as ENV variables called `ENV['ARTEMIS_OAUTH_APP_ID']`, `ENV['ARTEMIS_OAUTH_APP_SECRET']` and `ENV['ARTEMIS_BASE_URI']`
 
 They will be automatically detected and then you don't have to pass in any options:
 ```ruby
-client = ArtemisApi::Client.new('your_access_token', 'your_refresh_token')
+client = ArtemisApi::Client.new('your_access_token', 'your_refresh_token', token_expires_at)
 ```
 
 Once you have a client instance, you can use it to request information from Artemis.

--- a/artemis_api.gemspec
+++ b/artemis_api.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "oauth2"
   spec.add_development_dependency "webmock"
+  spec.add_development_dependency "activesupport"
 end

--- a/lib/artemis_api/client.rb
+++ b/lib/artemis_api/client.rb
@@ -2,26 +2,22 @@ module ArtemisApi
   class Client
     require 'oauth2'
     attr_reader :options, :objects, :access_token, :refresh_token, :oauth_client,
-                :oauth_token, :expires_in, :created_at, :expires_at
+                :oauth_token, :expires_at
 
-    def initialize(access_token, refresh_token, expires_in, created_at, options = {})
+    def initialize(access_token, refresh_token, expires_at, options = {})
       options[:app_id] ||= ENV['ARTEMIS_OAUTH_APP_ID']
       options[:app_secret] ||= ENV['ARTEMIS_OAUTH_APP_SECRET']
       options[:base_uri] ||= ENV['ARTEMIS_BASE_URI']
       @options = options
       @access_token = access_token
       @refresh_token = refresh_token
-      @expires_in = expires_in
-      @created_at = created_at
-      @expires_at = created_at.strftime('%s').to_i + expires_in
+      @expires_at = expires_at
 
       @oauth_client = OAuth2::Client.new(@options[:app_id], @options[:app_secret], site: @options[:base_uri])
       @oauth_token = OAuth2::AccessToken.from_hash(
                       oauth_client,
                       {access_token: @access_token,
                        refresh_token: @refresh_token,
-                       created_at: @created_at,
-                       expires_in: @expires_in,
                        expires_at: @expires_at})
       @objects = {}
     end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -6,12 +6,12 @@ class ClientTest < Minitest::Test
                app_secret: '67890',
                base_uri: 'http://localhost:3000'}
 
-    tomorrows_date = 1.days.from_now.to_i
+    tomorrows_date = 1.days.from_now
     client = ArtemisApi::Client.new('ya29', 'eyJh', tomorrows_date, options)
 
     assert_equal '12345', client.oauth_client.id
     assert_equal 'ya29', client.oauth_token.token
-    assert_equal tomorrows_date, client.oauth_token.expires_at
+    assert_equal tomorrows_date.to_i, client.oauth_token.expires_at
     assert_equal false, client.oauth_token.expired?
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -6,13 +6,12 @@ class ClientTest < Minitest::Test
                app_secret: '67890',
                base_uri: 'http://localhost:3000'}
 
-    todays_date = DateTime.now
-    client = ArtemisApi::Client.new('ya29', 'eyJh', 7200, todays_date, options)
+    tomorrows_date = 1.days.from_now.to_i
+    client = ArtemisApi::Client.new('ya29', 'eyJh', tomorrows_date, options)
 
     assert_equal '12345', client.oauth_client.id
     assert_equal 'ya29', client.oauth_token.token
-    assert_equal todays_date, client.oauth_token.params[:created_at]
-    assert_equal 7200, client.oauth_token.expires_in
+    assert_equal tomorrows_date, client.oauth_token.expires_at
     assert_equal false, client.oauth_token.expired?
   end
 end

--- a/test/facility_test.rb
+++ b/test/facility_test.rb
@@ -6,8 +6,8 @@ class FacilityTest < Minitest::Test
                app_secret: '67890',
                base_uri: 'http://localhost:3000'}
 
-    todays_date = DateTime.now
-    @client = ArtemisApi::Client.new('ya29', 'eyJh', 7200, todays_date, options)
+    tomorrows_date = 1.days.from_now
+    @client = ArtemisApi::Client.new('ya29', 'eyJh', tomorrows_date, options)
 
     stub_request(:get, 'http://localhost:3000/api/v3/facilities')
       .to_return(body: {data: [{id: '1', type: 'facilities', attributes: {id: 1, name: 'Sky Fresh'}}, {id: '2', type: 'facilities', attributes: {id: 2, name: 'Rare Dankness'}}]}.to_json)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,5 @@ require "artemis_api"
 
 require "minitest/autorun"
 require "webmock/minitest"
+require "active_support"
+require "active_support/core_ext/numeric"

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -6,8 +6,8 @@ class UserTest < Minitest::Test
                app_secret: '67890',
                base_uri: 'http://localhost:3000'}
 
-    todays_date = DateTime.now
-    @client = ArtemisApi::Client.new('ya29', 'eyJh', 7200, todays_date, options)
+    tomorrows_date = 1.days.from_now
+    @client = ArtemisApi::Client.new('ya29', 'eyJh', tomorrows_date, options)
 
     stub_request(:get, 'http://localhost:3000/api/v3/user')
       .to_return(body: {data: {id: '41', type: 'users', attributes: {id: 41, full_name: 'Jamey Hampton', email: 'jhampton@artemisag.com'}}}.to_json)


### PR DESCRIPTION
This is both more explicit than relying on the combination of `expires_in` and `created_at` and also saves a step of work for the user