### PR TITLE
Fixed formatting for URL w/ include & filters

### DIFF
--- a/lib/artemis_api/client.rb
+++ b/lib/artemis_api/client.rb
@@ -51,8 +51,12 @@ module ArtemisApi
             else
               "#{@options[:base_uri]}/api/v3/#{type}"
             end
+
       url = "#{url}?include=#{include}" if include
-      url = "#{url}?#{format_filters(filters)}" if filters
+      if filters
+        formatted_filters = format_filters(filters)
+        url = (include) ? "#{url}&#{formatted_filters}" : "#{url}?#{formatted_filters}"
+      end
 
       response = @oauth_token.get(url)
       if response.status == 200


### PR DESCRIPTION
This was breaking because the formatting was assuming you either had an include OR a filter and couldn't handle if you had both.