### PR TITLE
Fixing removal of record from cache

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artemis_api (0.1.0)
+    artemis_api (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/artemis_api/client.rb
+++ b/lib/artemis_api/client.rb
@@ -84,15 +84,7 @@ module ArtemisApi
     end
 
     def remove_record(type, id)
-      @objects[type].delete(id.to_i) if record_stored?(type, id)
-    end
-
-    def record_stored?(type, id)
-      get_record(type, id).present?
-    end
-
-    def remove_record(type, id)
-      @objects[type].delete(id.to_i)
+      @objects[type]&.delete(id.to_i)
     end
 
     def refresh

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -22,4 +22,22 @@ class ClientTest < Minitest::Test
     user = @client.current_user
     assert_equal user.class, ArtemisApi::User
   end
+
+  def test_remove_record
+    get_client
+
+    type = 'subscriptions'
+
+    # model type added once, removed twice
+    @client.store_record(type, 1, 'id' => 1)
+    assert_equal 1, @client.get_record(type, 1).id
+    @client.remove_record(type, 1)
+    assert_nil @client.get_record(type, 1)
+    assert_nothing_raised { @client.remove_record(type, 1) }
+
+    # model type not added, attempt to remove one
+    undefined_type = 'something'
+    assert_nil @client.instance_variable_get(:"@objects")[undefined_type]
+    assert_nothing_raised { @client.remove_record(undefined_type, 1) }
+  end
 end


### PR DESCRIPTION
- Reworked deletion to allow for a missing cache per-type
- Removed redeclaration of record deletion 
- Removed the now redundant `record_stored?`
- Added test

---

My initial fix for this wasn't quite right, and it looks like a bad merge/rebase brought in a dupe function declaration